### PR TITLE
Do not abort when uninstaller fails

### DIFF
--- a/packages/app-builder-lib/templates/nsis/include/installUtil.nsh
+++ b/packages/app-builder-lib/templates/nsis/include/installUtil.nsh
@@ -179,13 +179,9 @@ Function uninstallOldVersion
     ifErrors 0 ExecErrorHandler
       # this also failed...
       DetailPrint `Aborting, uninstall was not successful. Not able to launch uninstaller!`
-      SetErrorLevel 5
-      Abort "Cannot uninstall"
   ExecErrorHandler:
   ${if} $R0 != 0
     DetailPrint `Aborting, uninstall was not successful. Uninstaller error code: $R0.`
-    SetErrorLevel 5
-    Abort "Cannot uninstall"
   ${endif}
   Done:
 FunctionEnd


### PR DESCRIPTION
This fixes #4057, the most commented open issue.

![image](https://user-images.githubusercontent.com/658230/92672452-61e3a280-f321-11ea-8c1d-05d0280b8052.png)

Current behavior: when installer detects previously installed version, it tries to run its uninstaller. And if the uninstaller is missing/entire installation directory is missing/uninstaller is damaged/uninstaller fails with error code - then the installation is aborted and the user has only one option: "Cancel" button.

Proposed behavior: ignore and proceed to installation. The most popular scenario causing the bug #4057 is user manually deleting the installation directory. *After that, the user is unable to install the app again.* The only way for the user to fix the issue is to manually delete the uninstall registry entry. The sole purpose of the installer is to install the app, so I think it should proceed to installation. Error logging/displaying the error in the installer window might be added latter, but the logic should never prevent the user from installing the app.